### PR TITLE
Add vectorized array operations and benchmarks

### DIFF
--- a/Equativ.RoaringBitmaps.Benchmarks/ArrayContainerVectorOpsBenchmark.cs
+++ b/Equativ.RoaringBitmaps.Benchmarks/ArrayContainerVectorOpsBenchmark.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+
+namespace Equativ.RoaringBitmaps.Benchmark;
+
+[MemoryDiagnoser(false)]
+public class ArrayContainerVectorOpsBenchmark
+{
+    private ArrayContainer[] _containers = Array.Empty<ArrayContainer>();
+
+    [Params(1000)]
+    public int Size { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var rnd = new Random(42);
+        _containers = new ArrayContainer[Size];
+        for (int i = 0; i < Size; i++)
+        {
+            var start = rnd.Next(0, ushort.MaxValue - 200);
+            _containers[i] = ArrayContainer.Create(Enumerable.Range(start, 100).Select(x => (ushort)x).ToArray());
+        }
+    }
+
+    private static ulong[][] FreshBitmaps(int size)
+    {
+        var bitmaps = new ulong[size][];
+        for (int i = 0; i < size; i++)
+        {
+            bitmaps[i] = new ulong[1024];
+        }
+        return bitmaps;
+    }
+
+    [Benchmark]
+    public int OrScalar()
+    {
+        var bitmaps = FreshBitmaps(Size);
+        int total = 0;
+        for (int i = 0; i < _containers.Length; i++)
+        {
+            total += _containers[i].OrArray(bitmaps[i]);
+        }
+        return total;
+    }
+
+    [Benchmark]
+    public int OrVector()
+    {
+        var bitmaps = FreshBitmaps(Size);
+        int total = 0;
+        for (int i = 0; i < _containers.Length; i++)
+        {
+            total += _containers[i].OrArrayVectorized(bitmaps[i]);
+        }
+        return total;
+    }
+
+    [Benchmark]
+    public int XorScalar()
+    {
+        var bitmaps = FreshBitmaps(Size);
+        int total = 0;
+        for (int i = 0; i < _containers.Length; i++)
+        {
+            total += _containers[i].XorArray(bitmaps[i]);
+        }
+        return total;
+    }
+
+    [Benchmark]
+    public int XorVector()
+    {
+        var bitmaps = FreshBitmaps(Size);
+        int total = 0;
+        for (int i = 0; i < _containers.Length; i++)
+        {
+            total += _containers[i].XorArrayVectorized(bitmaps[i]);
+        }
+        return total;
+    }
+
+    [Benchmark]
+    public int AndNotScalar()
+    {
+        var bitmaps = FreshBitmaps(Size);
+        int total = 0;
+        for (int i = 0; i < _containers.Length; i++)
+        {
+            total += _containers[i].AndNotArray(bitmaps[i]);
+        }
+        return total;
+    }
+
+    [Benchmark]
+    public int AndNotVector()
+    {
+        var bitmaps = FreshBitmaps(Size);
+        int total = 0;
+        for (int i = 0; i < _containers.Length; i++)
+        {
+            total += _containers[i].AndNotArrayVectorized(bitmaps[i]);
+        }
+        return total;
+    }
+}

--- a/Equativ.RoaringBitmaps.Benchmarks/ContainerOperatorBenchmark.cs
+++ b/Equativ.RoaringBitmaps.Benchmarks/ContainerOperatorBenchmark.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+
+namespace Equativ.RoaringBitmaps.Benchmark;
+
+[MemoryDiagnoser(false)]
+public class ContainerOperatorBenchmark
+{
+    private Container[] _lhs = Array.Empty<Container>();
+    private Container[] _rhs = Array.Empty<Container>();
+
+    [Params(1000)]
+    public int Size { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var rnd = new Random(42);
+        _lhs = new Container[Size];
+        _rhs = new Container[Size];
+        for (int i = 0; i < Size; i++)
+        {
+            var start1 = rnd.Next(0, ushort.MaxValue - 200);
+            var start2 = rnd.Next(0, ushort.MaxValue - 200);
+            _lhs[i] = ArrayContainer.Create(Enumerable.Range(start1, 100).Select(x => (ushort)x).ToArray());
+            _rhs[i] = ArrayContainer.Create(Enumerable.Range(start2, 100).Select(x => (ushort)x).ToArray());
+        }
+    }
+
+    [Benchmark]
+    public int Or()
+    {
+        int total = 0;
+        for (int i = 0; i < _lhs.Length; i++)
+        {
+            total += (_lhs[i] | _rhs[i]).Cardinality;
+        }
+        return total;
+    }
+
+    [Benchmark]
+    public int Xor()
+    {
+        int total = 0;
+        for (int i = 0; i < _lhs.Length; i++)
+        {
+            total += (_lhs[i] ^ _rhs[i]).Cardinality;
+        }
+        return total;
+    }
+
+    [Benchmark]
+    public int And()
+    {
+        int total = 0;
+        for (int i = 0; i < _lhs.Length; i++)
+        {
+            total += (_lhs[i] & _rhs[i]).Cardinality;
+        }
+        return total;
+    }
+
+    [Benchmark]
+    public int AndNot()
+    {
+        int total = 0;
+        for (int i = 0; i < _lhs.Length; i++)
+        {
+            total += Container.AndNot(_lhs[i], _rhs[i]).Cardinality;
+        }
+        return total;
+    }
+}

--- a/Equativ.RoaringBitmaps.Tests/ArrayContainerArrayOpsTests.cs
+++ b/Equativ.RoaringBitmaps.Tests/ArrayContainerArrayOpsTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Equativ.RoaringBitmaps.Tests;
+
+public class ArrayContainerArrayOpsTests
+{
+    private static bool BitSet(ulong[] bitmap, int value)
+    {
+        int index = value >> 6;
+        ulong mask = 1UL << value;
+        return (bitmap[index] & mask) != 0;
+    }
+
+    [Fact]
+    public void OrArray_EmptyBitmap_SetsAllBits()
+    {
+        var ac = ArrayContainer.Create(new ushort[] {1, 63, 64, 500});
+        var bitmap = new ulong[1024];
+
+        int added = ac.OrArray(bitmap);
+
+        Assert.Equal(ac.Cardinality, added);
+        Assert.True(BitSet(bitmap, 1));
+        Assert.True(BitSet(bitmap, 63));
+        Assert.True(BitSet(bitmap, 64));
+        Assert.True(BitSet(bitmap, 500));
+}
+
+    [Fact]
+    public void OrArray_WithExistingBits_AddsOnlyMissing()
+    {
+        var ac = ArrayContainer.Create(new ushort[] {1, 200, 500});
+        var bitmap = new ulong[1024];
+        // pre-set bit 1 and 200
+        bitmap[1 >> 6] |= 1UL << 1;
+        bitmap[200 >> 6] |= 1UL << 200;
+
+        int added = ac.OrArray(bitmap);
+
+        Assert.Equal(1, added); // only value 500 was added
+        Assert.True(BitSet(bitmap, 1));
+        Assert.True(BitSet(bitmap, 200));
+        Assert.True(BitSet(bitmap, 500));
+    }
+
+    [Fact]
+    public void OrArrayVectorized_MatchesScalar()
+    {
+        var ac = ArrayContainer.Create(new ushort[] {10, 20, 30});
+        var bitmapScalar = new ulong[1024];
+        var bitmapVector = new ulong[1024];
+
+        int deltaScalar = ac.OrArray(bitmapScalar);
+        int deltaVector = ac.OrArrayVectorized(bitmapVector);
+
+        Assert.Equal(deltaScalar, deltaVector);
+        Assert.Equal(bitmapScalar, bitmapVector);
+    }
+
+    [Fact]
+    public void XorArray_EmptyBitmap_TogglesBits()
+    {
+        var ac = ArrayContainer.Create(new ushort[] {2, 100});
+        var bitmap = new ulong[1024];
+
+        int delta = ac.XorArray(bitmap);
+
+        Assert.Equal(ac.Cardinality, delta);
+        Assert.True(BitSet(bitmap, 2));
+        Assert.True(BitSet(bitmap, 100));
+    }
+
+    [Fact]
+    public void XorArray_WithExistingBits_TogglesOff()
+    {
+        var ac = ArrayContainer.Create(new ushort[] {2, 100});
+        var bitmap = new ulong[1024];
+        bitmap[2 >> 6] |= 1UL << 2; // set bit 2
+
+        int delta = ac.XorArray(bitmap);
+
+        Assert.Equal(0, delta); // one added, one removed
+        Assert.False(BitSet(bitmap, 2));
+        Assert.True(BitSet(bitmap, 100));
+    }
+
+    [Fact]
+    public void XorArrayVectorized_MatchesScalar()
+    {
+        var ac = ArrayContainer.Create(new ushort[] {5, 6});
+        var bmp1 = new ulong[1024];
+        var bmp2 = new ulong[1024];
+
+        int d1 = ac.XorArray(bmp1);
+        int d2 = ac.XorArrayVectorized(bmp2);
+
+        Assert.Equal(d1, d2);
+        Assert.Equal(bmp1, bmp2);
+    }
+
+    [Fact]
+    public void AndNotArray_NoBitsSet_NoChange()
+    {
+        var ac = ArrayContainer.Create(new ushort[] {3, 30});
+        var bitmap = new ulong[1024];
+
+        int delta = ac.AndNotArray(bitmap);
+
+        Assert.Equal(0, delta);
+        Assert.False(BitSet(bitmap, 3));
+        Assert.False(BitSet(bitmap, 30));
+    }
+
+    [Fact]
+    public void AndNotArray_RemovesExistingBits()
+    {
+        var ac = ArrayContainer.Create(new ushort[] {3, 30});
+        var bitmap = new ulong[1024];
+        bitmap[3 >> 6] |= 1UL << 3;
+        bitmap[30 >> 6] |= 1UL << 30;
+        bitmap[40 >> 6] |= 1UL << 40;
+
+        int delta = ac.AndNotArray(bitmap);
+
+        Assert.Equal(-2, delta);
+        Assert.False(BitSet(bitmap, 3));
+        Assert.False(BitSet(bitmap, 30));
+        Assert.True(BitSet(bitmap, 40));
+    }
+
+    [Fact]
+    public void AndNotArrayVectorized_MatchesScalar()
+    {
+        var ac = ArrayContainer.Create(new ushort[] {7, 9});
+        var bmp1 = new ulong[1024];
+        var bmp2 = new ulong[1024];
+        bmp1[7 >> 6] |= 1UL << 7;
+        bmp2[7 >> 6] |= 1UL << 7;
+
+        int d1 = ac.AndNotArray(bmp1);
+        int d2 = ac.AndNotArrayVectorized(bmp2);
+
+        Assert.Equal(d1, d2);
+        Assert.Equal(bmp1, bmp2);
+    }
+}

--- a/Equativ.RoaringBitmaps.Tests/ContainerOperatorTests.cs
+++ b/Equativ.RoaringBitmaps.Tests/ContainerOperatorTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Equativ.RoaringBitmaps.Tests;
+
+public class ContainerOperatorTests
+{
+    private static List<int> ToList(Container c)
+    {
+        var list = new List<int>();
+        c.EnumerateFill(list, 0);
+        return list;
+    }
+
+    [Fact]
+    public void Or_ArrayContainers_ThroughBaseOperator()
+    {
+        Container a = ArrayContainer.Create(new ushort[] {1, 3});
+        Container b = ArrayContainer.Create(new ushort[] {3, 5});
+
+        Container result = a | b;
+
+        Assert.Equal(new[] {1,3,5}, ToList(result));
+    }
+
+    [Fact]
+    public void Xor_MixedContainers_ThroughBaseOperator()
+    {
+        Container a = ArrayContainer.Create(new ushort[] {1, 2});
+        Container b = BitmapContainer.Create(new ushort[] {2, 4});
+
+        Container result = a ^ b;
+
+        Assert.Equal(new[] {1,4}, ToList(result));
+    }
+
+    [Fact]
+    public void And_MixedContainers_ThroughBaseOperator()
+    {
+        Container a = ArrayContainer.Create(new ushort[] {10, 11, 12});
+        Container b = BitmapContainer.Create(new ushort[] {11, 13});
+
+        Container result = a & b;
+
+        Assert.Equal(new[] {11}, ToList(result));
+    }
+
+    [Fact]
+    public void AndNot_MixedContainers()
+    {
+        Container a = ArrayContainer.Create(new ushort[] {8, 9, 10});
+        Container b = BitmapContainer.Create(new ushort[] {9});
+
+        Container result = Container.AndNot(a, b);
+
+        Assert.Equal(new[] {8,10}, ToList(result));
+    }
+}

--- a/Equativ.RoaringBitmaps/ArrayContainer.cs
+++ b/Equativ.RoaringBitmaps/ArrayContainer.cs
@@ -208,11 +208,24 @@ internal class ArrayContainer : Container, IEquatable<ArrayContainer>
         }
 
         Span<ulong> scratch = stackalloc ulong[BitmapContainerBitmapLength];
+        scratch.Clear();
+        var minIdx = BitmapContainerBitmapLength;
+        var maxIdx = -1;
         for (var i = 0; i < _cardinality; i++)
         {
             var v = _content[i];
-            scratch[v >> 6] |= 1UL << v;
+            var idx = v >> 6;
+            scratch[idx] |= 1UL << v;
+            if (idx < minIdx) minIdx = idx;
+            if (idx > maxIdx) maxIdx = idx;
         }
+        if (maxIdx < 0)
+        {
+            return 0;
+        }
+
+        minIdx &= ~3;
+        maxIdx = (maxIdx | 3);
 
         var added = 0;
 
@@ -221,7 +234,7 @@ internal class ArrayContainer : Container, IEquatable<ArrayContainer>
             fixed (ulong* t = scratch)
             fixed (ulong* b = bitmap)
             {
-                for (int k = 0; k < BitmapContainerBitmapLength; k += 4)
+                for (int k = minIdx; k <= maxIdx; k += 4)
                 {
                     var prev = Avx.LoadVector256(b + k);
                     var tmp = Avx.LoadVector256(t + k);
@@ -263,11 +276,24 @@ internal class ArrayContainer : Container, IEquatable<ArrayContainer>
         }
 
         Span<ulong> scratch = stackalloc ulong[BitmapContainerBitmapLength];
+        scratch.Clear();
+        var minIdx = BitmapContainerBitmapLength;
+        var maxIdx = -1;
         for (var i = 0; i < _cardinality; i++)
         {
             var v = _content[i];
-            scratch[v >> 6] |= 1UL << v;
+            var idx = v >> 6;
+            scratch[idx] |= 1UL << v;
+            if (idx < minIdx) minIdx = idx;
+            if (idx > maxIdx) maxIdx = idx;
         }
+        if (maxIdx < 0)
+        {
+            return 0;
+        }
+
+        minIdx &= ~3;
+        maxIdx = (maxIdx | 3);
 
         var delta = 0;
 
@@ -276,7 +302,7 @@ internal class ArrayContainer : Container, IEquatable<ArrayContainer>
             fixed (ulong* t = scratch)
             fixed (ulong* b = bitmap)
             {
-                for (int k = 0; k < BitmapContainerBitmapLength; k += 4)
+                for (int k = minIdx; k <= maxIdx; k += 4)
                 {
                     var prev = Avx.LoadVector256(b + k);
                     var tmp = Avx.LoadVector256(t + k);
@@ -324,11 +350,24 @@ internal class ArrayContainer : Container, IEquatable<ArrayContainer>
         }
 
         Span<ulong> scratch = stackalloc ulong[BitmapContainerBitmapLength];
+        scratch.Clear();
+        var minIdx = BitmapContainerBitmapLength;
+        var maxIdx = -1;
         for (var i = 0; i < _cardinality; i++)
         {
             var v = _content[i];
-            scratch[v >> 6] |= 1UL << v;
+            var idx = v >> 6;
+            scratch[idx] |= 1UL << v;
+            if (idx < minIdx) minIdx = idx;
+            if (idx > maxIdx) maxIdx = idx;
         }
+        if (maxIdx < 0)
+        {
+            return 0;
+        }
+
+        minIdx &= ~3;
+        maxIdx = (maxIdx | 3);
 
         var delta = 0;
 
@@ -337,7 +376,7 @@ internal class ArrayContainer : Container, IEquatable<ArrayContainer>
             fixed (ulong* t = scratch)
             fixed (ulong* b = bitmap)
             {
-                for (int k = 0; k < BitmapContainerBitmapLength; k += 4)
+                for (int k = minIdx; k <= maxIdx; k += 4)
                 {
                     var prev = Avx.LoadVector256(b + k);
                     var tmp = Avx.LoadVector256(t + k);

--- a/Equativ.RoaringBitmaps/ArrayContainer.cs
+++ b/Equativ.RoaringBitmaps/ArrayContainer.cs
@@ -208,7 +208,7 @@ internal class ArrayContainer : Container, IEquatable<ArrayContainer>
         }
 
         Span<ulong> scratch = stackalloc ulong[BitmapContainerBitmapLength];
-        scratch.Clear();
+        scratch.Clear(); // zero-initialize the temporary bitmap
         var minIdx = BitmapContainerBitmapLength;
         var maxIdx = -1;
         for (var i = 0; i < _cardinality; i++)
@@ -224,8 +224,8 @@ internal class ArrayContainer : Container, IEquatable<ArrayContainer>
             return 0;
         }
 
-        minIdx &= ~3;
-        maxIdx = (maxIdx | 3);
+        minIdx &= ~3; // round down to nearest multiple of four
+        maxIdx = (maxIdx | 3); // round up to next multiple of four minus one
 
         var added = 0;
 
@@ -276,7 +276,7 @@ internal class ArrayContainer : Container, IEquatable<ArrayContainer>
         }
 
         Span<ulong> scratch = stackalloc ulong[BitmapContainerBitmapLength];
-        scratch.Clear();
+        scratch.Clear(); // zero-initialize the temporary bitmap
         var minIdx = BitmapContainerBitmapLength;
         var maxIdx = -1;
         for (var i = 0; i < _cardinality; i++)
@@ -292,8 +292,8 @@ internal class ArrayContainer : Container, IEquatable<ArrayContainer>
             return 0;
         }
 
-        minIdx &= ~3;
-        maxIdx = (maxIdx | 3);
+        minIdx &= ~3; // align down so AVX loads start on a 4-word boundary
+        maxIdx = (maxIdx | 3); // align up so the loop processes whole vectors
 
         var delta = 0;
 
@@ -350,7 +350,7 @@ internal class ArrayContainer : Container, IEquatable<ArrayContainer>
         }
 
         Span<ulong> scratch = stackalloc ulong[BitmapContainerBitmapLength];
-        scratch.Clear();
+        scratch.Clear(); // zero-initialize the temporary bitmap
         var minIdx = BitmapContainerBitmapLength;
         var maxIdx = -1;
         for (var i = 0; i < _cardinality; i++)
@@ -366,8 +366,8 @@ internal class ArrayContainer : Container, IEquatable<ArrayContainer>
             return 0;
         }
 
-        minIdx &= ~3;
-        maxIdx = (maxIdx | 3);
+        minIdx &= ~3; // start index rounded down to a multiple of four
+        maxIdx = (maxIdx | 3); // end index rounded up to cover final vector
 
         var delta = 0;
 

--- a/Equativ.RoaringBitmaps/Equativ.RoaringBitmaps.csproj
+++ b/Equativ.RoaringBitmaps/Equativ.RoaringBitmaps.csproj
@@ -11,6 +11,7 @@
     <Authors>Equativ.RoaringBitmaps Contributors</Authors>
     <Product>Equativ.RoaringBitmaps</Product>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
## Summary
- implement Vector256-enabled variants of `OrArray`, `XorArray` and `AndNotArray`
- expose benchmark suite `ArrayContainerVectorOpsBenchmark` comparing scalar and vector paths
- add tests checking vectorized methods behave the same as the original ones
- allow unsafe code in main project

## Testing
- `dotnet test Equativ.RoaringBitmaps.sln --verbosity minimal`
- `dotnet build Equativ.RoaringBitmaps.sln -c Release --no-restore --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_68872eeb0af08325aeef78a2c5cf90e2