### PR TITLE
Add multi-bitmap And API and benchmark

### DIFF
--- a/Equativ.RoaringBitmaps.Benchmarks/AndBenchmark.cs
+++ b/Equativ.RoaringBitmaps.Benchmarks/AndBenchmark.cs
@@ -1,0 +1,42 @@
+using BenchmarkDotNet.Attributes;
+using Equativ.RoaringBitmaps.Datasets;
+
+namespace Equativ.RoaringBitmaps.Benchmarks;
+
+[MemoryDiagnoser(false)]
+public class AndBenchmark
+{
+    private RoaringBitmap _bitmap1 = null!;
+    private RoaringBitmap _bitmap2 = null!;
+    private RoaringBitmap _bitmap3 = null!;
+
+    [Params(
+        Paths.Census1881,
+        Paths.Census1881Srt,
+        Paths.CensusIncome,
+        Paths.Dimension003,
+        Paths.Dimension008,
+        Paths.Dimension033,
+        Paths.UsCensus2000,
+        Paths.WeatherSept85,
+        Paths.WeatherSept85Srt,
+        Paths.WikileaksNoQuotes,
+        Paths.WikileaksNoQuotesSrt)]
+    public string FileName { get; set; } = string.Empty;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        using var provider = new ZipRealDataProvider(FileName);
+        var bitmaps = provider.ToArray();
+        _bitmap1 = bitmaps[0];
+        _bitmap2 = bitmaps[1];
+        _bitmap3 = bitmaps[2];
+    }
+
+    [Benchmark]
+    public long And()
+    {
+        return RoaringBitmap.And(_bitmap1, _bitmap2, _bitmap3).Cardinality;
+    }
+}

--- a/Equativ.RoaringBitmaps.Tests/RoaringBitmapTests.cs
+++ b/Equativ.RoaringBitmaps.Tests/RoaringBitmapTests.cs
@@ -236,6 +236,19 @@ public class RoaringBitmapTests
     }
 
     [Fact]
+    public void AndMultiple()
+    {
+        var rb1 = RoaringBitmap.Create(Enumerable.Range(0, 100));
+        var rb2 = RoaringBitmap.Create(Enumerable.Range(50, 100));
+        var rb3 = RoaringBitmap.Create(Enumerable.Range(75, 100));
+
+        var expected = (rb1 & rb2) & rb3;
+        var actual = RoaringBitmap.And(rb1, rb2, rb3);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
     public void BasicCreate()
     {
         var rb = RoaringBitmap.Create(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);

--- a/Equativ.RoaringBitmaps.Tests/UtilsTests.cs
+++ b/Equativ.RoaringBitmaps.Tests/UtilsTests.cs
@@ -1,0 +1,35 @@
+using Xunit;
+
+namespace Equativ.RoaringBitmaps.Tests;
+
+public class UtilsTests
+{
+    [Fact]
+    public void IntersectArrays_TwoSets()
+    {
+        ushort[] set1 = {1, 2, 3};
+        ushort[] set2 = {2, 3, 4};
+        ushort[] buffer = new ushort[3];
+
+        int count = Utils.IntersectArrays(buffer, set1, set2);
+
+        Assert.Equal(2, count);
+        Assert.Equal((ushort)2, buffer[0]);
+        Assert.Equal((ushort)3, buffer[1]);
+    }
+
+    [Fact]
+    public void IntersectArrays_MultipleSets()
+    {
+        ushort[] set1 = {1, 2, 3, 4, 5};
+        ushort[] set2 = {2, 4, 6};
+        ushort[] set3 = {0, 2, 4, 8};
+        ushort[] buffer = new ushort[5];
+
+        int count = Utils.IntersectArrays(buffer, set1, set2, set3);
+
+        Assert.Equal(2, count);
+        Assert.Equal((ushort)2, buffer[0]);
+        Assert.Equal((ushort)4, buffer[1]);
+    }
+}

--- a/Equativ.RoaringBitmaps/RoaringBitmap.cs
+++ b/Equativ.RoaringBitmaps/RoaringBitmap.cs
@@ -180,6 +180,31 @@ public class RoaringBitmap : IEnumerable<int>, IEquatable<RoaringBitmap>
     }
 
     /// <summary>
+    /// Bitwise And operation of multiple RoaringBitmaps
+    /// </summary>
+    /// <param name="candidates">RoaringBitmaps to intersect</param>
+    /// <returns>RoaringBitmap</returns>
+    public static RoaringBitmap And(params RoaringBitmap[] candidates)
+    {
+        if (candidates == null)
+        {
+            throw new ArgumentNullException(nameof(candidates));
+        }
+        if (candidates.Length == 0)
+        {
+            throw new ArgumentException("At least one candidate is required", nameof(candidates));
+        }
+
+        var result = candidates[0] ?? throw new ArgumentNullException(nameof(candidates), "Bitmap at index 0 is null");
+        for (var i = 1; i < candidates.Length; i++)
+        {
+            var candidate = candidates[i] ?? throw new ArgumentNullException(nameof(candidates), $"Bitmap at index {i} is null");
+            result = result & candidate;
+        }
+        return result;
+    }
+
+    /// <summary>
     /// Bitwise AndNot operation of two RoaringBitmaps
     /// </summary>
     /// <param name="x">RoaringBitmap</param>

--- a/Equativ.RoaringBitmaps/Utils.cs
+++ b/Equativ.RoaringBitmaps/Utils.cs
@@ -153,6 +153,28 @@ internal static class Utils
         return pos;
     }
 
+    public static int IntersectArrays(ushort[] buffer, params ushort[][] sets)
+    {
+        if (sets.Length == 0)
+        {
+            return 0;
+        }
+
+        if (sets.Length == 1)
+        {
+            sets[0].AsSpan().CopyTo(buffer);
+            return sets[0].Length;
+        }
+
+        var cardinality = IntersectArrays(sets[0].AsSpan(), sets[1].AsSpan(), buffer);
+        for (var i = 2; i < sets.Length && cardinality > 0; i++)
+        {
+            cardinality = IntersectArrays(buffer.AsSpan(0, cardinality), sets[i], buffer);
+        }
+
+        return cardinality;
+    }
+
     public static int IntersectArrays(ReadOnlySpan<ushort> set1, ReadOnlySpan<ushort> set2, ushort[] buffer)
     {
         if (set1.Length << 6 < set2.Length)


### PR DESCRIPTION
## Summary
- add `RoaringBitmap.And` API for intersecting multiple bitmaps
- add unit test for multi-bitmap AND
- add benchmark tracking allocations for `RoaringBitmap.And`
- add `Utils.IntersectArrays` overload for intersecting multiple sets

## Testing
- `dotnet test`
- `dotnet build Equativ.RoaringBitmaps.Benchmarks/Equativ.RoaringBitmaps.Benchmarks.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68909cad2e588325b93d91b23cc4e67a